### PR TITLE
Feature: add minor changes/APIs for requirements

### DIFF
--- a/togather-common/src/main/java/com/togather/partyroom/tags/repository/PartyRoomCustomTagRepository.java
+++ b/togather-common/src/main/java/com/togather/partyroom/tags/repository/PartyRoomCustomTagRepository.java
@@ -1,13 +1,14 @@
 package com.togather.partyroom.tags.repository;
 
-import com.togather.partyroom.core.model.PartyRoom;
 import com.togather.partyroom.tags.model.PartyRoomCustomTag;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
+import java.awt.print.Pageable;
 import java.util.List;
-import java.util.Optional;
 
 public interface PartyRoomCustomTagRepository extends JpaRepository<PartyRoomCustomTag, Long> {
     PartyRoomCustomTag findByTagContent(String tagContent);
+
+    List<PartyRoomCustomTag> findAllByOrderByTagCountDesc(Limit limit);
 }

--- a/togather-common/src/main/java/com/togather/partyroom/tags/service/PartyRoomCustomTagService.java
+++ b/togather-common/src/main/java/com/togather/partyroom/tags/service/PartyRoomCustomTagService.java
@@ -9,13 +9,15 @@ import com.togather.partyroom.tags.model.PartyRoomCustomTagDto;
 import com.togather.partyroom.tags.model.PartyRoomCustomTagRel;
 import com.togather.partyroom.tags.repository.PartyRoomCustomTagRelRepository;
 import com.togather.partyroom.tags.repository.PartyRoomCustomTagRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Limit;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -105,5 +107,11 @@ public class PartyRoomCustomTagService {
 
         // Tags only on after: add relation between tag and party room
         afterList.stream().filter(afterDto -> !beforeTagContent.contains(afterDto.getTagContent())).forEach(afterDto -> registerTag(partyRoomDto, afterDto));
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> getPopularTags(int limit) {
+        List<PartyRoomCustomTag> partyRoomCustomTags = partyRoomCustomTagRepository.findAllByOrderByTagCountDesc(Limit.of(limit));
+        return partyRoomCustomTags.stream().map(PartyRoomCustomTag::getTagContent).toList();
     }
 }

--- a/togather-web/src/main/java/com/togather/common/response/ResponseFilter.java
+++ b/togather-web/src/main/java/com/togather/common/response/ResponseFilter.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ResponseFilter {
 
+    MEMBER_DTO_EXCLUDE_PII_WITH_NAME(MemberDto.class, new String[] {"password", "profilePicFile"}),
     MEMBER_DTO_EXCLUDE_PII(MemberDto.class, new String[] {"memberName", "password", "profilePicFile"}),
     PARTY_ROOM_DTO_SIMPLE(PartyRoomDto.class, new String[] {"partyRoomDesc"}),
 //    PARTY_ROOM_RESERVATION_DTO(PartyRoomReservationDto.class, new String[]{}),

--- a/togather-web/src/main/java/com/togather/member/MemberController.java
+++ b/togather-web/src/main/java/com/togather/member/MemberController.java
@@ -1,5 +1,7 @@
 package com.togather.member;
 
+import com.togather.common.response.AddJsonFilters;
+import com.togather.common.response.ResponseFilter;
 import com.togather.member.dto.LoginDto;
 import com.togather.member.model.MemberDto;
 import com.togather.member.service.MemberService;
@@ -15,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.MappingJacksonValue;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -60,5 +64,16 @@ public class MemberController {
         httpHeaders.add(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + token);
 
         return new ResponseEntity<>(token, httpHeaders, HttpStatus.OK);
+    }
+
+    @PostMapping("/getUserInfo")
+    @Operation(summary = "get info of user logged in", description = "로그인한 사용자 정보 조회 API")
+    @ApiResponse(responseCode = "200", description = "success", content = @Content(schema = @Schema(implementation = MemberDto.class)))
+    @PreAuthorize("isAuthenticated()")
+    @ApiResponse(responseCode = "401", description = "user not logged in (No JWT token)", content = @Content)
+    @AddJsonFilters(filters = ResponseFilter.MEMBER_DTO_EXCLUDE_PII_WITH_NAME)
+    public MappingJacksonValue getUserInfo() {
+        MemberDto loginUser = memberService.findByAuthentication(SecurityContextHolder.getContext().getAuthentication());
+        return new MappingJacksonValue(loginUser);
     }
 }


### PR DESCRIPTION
## 개요 :mag:
<!-- 어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요. -->


## 작업사항 :memo:
* 태그 상위 10개 반환하는 API 추가
* Partyroom detail API 응답값으로 host name 추가
* 토큰을 받아서 개인정보 반환하는 API 추가


## 테스트 방법 :hammer_and_wrench:
<img width="952" alt="image" src="https://github.com/togather-2024/togather-backend/assets/37106166/98c1658c-ccb9-453a-82ce-9ab156c2d3af">

위 API 에 대한 쿼리 - 정상 동작 확인

<img width="1131" alt="image" src="https://github.com/togather-2024/togather-backend/assets/37106166/5fc6e409-7a75-492e-b2d8-9a95d66c4824">

