### PR TITLE
Feature: modify request parameters for type LocalDateTime as KST converted values

### DIFF
--- a/togather-common/src/main/java/com/togather/common/util/LocalDateTimeUtils.java
+++ b/togather-common/src/main/java/com/togather/common/util/LocalDateTimeUtils.java
@@ -1,0 +1,20 @@
+package com.togather.common.util;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class LocalDateTimeUtils {
+
+    private static final String KST_ZONE_ID = "Asia/Seoul";
+
+    public static LocalDateTime convertFromUtc(LocalDateTime utc, ZoneId zoneId) {
+        ZonedDateTime zonedDateTime = utc.atZone(ZoneId.of("UTC"));
+        return zonedDateTime.withZoneSameInstant(zoneId).toLocalDateTime();
+    }
+
+    // UTC로 입력된 시간을 KST로 변환해주는 로직
+    public static LocalDateTime convertToKstFromUtc(LocalDateTime utc) {
+        return convertFromUtc(utc, ZoneId.of(KST_ZONE_ID));
+    }
+}

--- a/togather-web/src/main/java/com/togather/common/request/TimeZoneRequestBodyAdvice.java
+++ b/togather-web/src/main/java/com/togather/common/request/TimeZoneRequestBodyAdvice.java
@@ -1,0 +1,60 @@
+package com.togather.common.request;
+
+import com.togather.common.exception.ErrorCode;
+import com.togather.common.exception.TogatherApiException;
+import com.togather.common.util.LocalDateTimeUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdvice;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+@RestControllerAdvice
+@Slf4j
+public class TimeZoneRequestBodyAdvice implements RequestBodyAdvice {
+    @Override
+    public boolean supports(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public HttpInputMessage beforeBodyRead(HttpInputMessage inputMessage, MethodParameter parameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) throws IOException {
+        return inputMessage;
+    }
+
+    /**
+     * Changes the input for fields with class 'LocalDateTime' to a value of same time in KST timezone
+     */
+    @Override
+    public Object afterBodyRead(Object body, HttpInputMessage inputMessage, MethodParameter parameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+        List<Field> fieldList = Arrays.asList(body.getClass().getDeclaredFields());
+        fieldList.stream()
+                .filter(field -> field.getType() == LocalDateTime.class)
+                .forEach(field -> {
+                    field.setAccessible(true);
+                    try {
+                        field.set(body, LocalDateTimeUtils.convertToKstFromUtc((LocalDateTime) field.get(body)));
+                    } catch (IllegalAccessException e) {
+                        // This exception can never been thrown because field is setAccessible to true
+                        log.error("[TimeZoneRequestBodyAdvice] error occurred while handling parameters with localdatetime. method: {}", parameter.getMethod().getName());
+                        throw new TogatherApiException(ErrorCode.INTERNAL_SERVER_ERROR);
+                    }
+                });
+        ;
+
+        return body;
+    }
+
+    @Override
+    public Object handleEmptyBody(Object body, HttpInputMessage inputMessage, MethodParameter parameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return null;
+    }
+}

--- a/togather-web/src/main/java/com/togather/common/request/TimeZoneRequestBodyAdvice.java
+++ b/togather-web/src/main/java/com/togather/common/request/TimeZoneRequestBodyAdvice.java
@@ -20,11 +20,18 @@ import java.util.List;
 @RestControllerAdvice
 @Slf4j
 public class TimeZoneRequestBodyAdvice implements RequestBodyAdvice {
+
+    /**
+     * Always return true, so applied to every API calls (every controller methods)
+     */
     @Override
     public boolean supports(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
         return true;
     }
 
+    /**
+     * Nothing changed
+     */
     @Override
     public HttpInputMessage beforeBodyRead(HttpInputMessage inputMessage, MethodParameter parameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) throws IOException {
         return inputMessage;
@@ -53,6 +60,10 @@ public class TimeZoneRequestBodyAdvice implements RequestBodyAdvice {
         return body;
     }
 
+
+    /**
+     * Nothing changed
+     */
     @Override
     public Object handleEmptyBody(Object body, HttpInputMessage inputMessage, MethodParameter parameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
         return null;


### PR DESCRIPTION
## 개요 :mag:
* requestBody 파라미터(e.g. 예약 등록 API)의 경우에 UTC -> KST 로 변환하여 저장

## 작업사항 :memo:
* 기존 로직은 timezone과 관련없이 입력된 시간 자체를 저장하도록 동작함.
* 그런데 FE 에서 위 API를 호출할 때 자동으로 UTC로 변환이 된다고 함(e.g. 한국시간 17시를 입력했는데 UTC인 8시가 입력됨)
* 그래서 오전 8시에 예약이 된 것으로 입력됨
* 이를 방지하기 위해서 FE에서 LocalDateTIme 형식으로 주는 모든 API 는 UTC 로 변환되어 줄 것이며, BE의 DB 및 로직 일관성을 위해 KST 로 변환 후, 작업들을 진행할 것으로 협의했습니다
* reservation register 뿐 아니라 다른 API의 경우에도 localDateTime 타입의 필드를 가지는 API에는 공동으로 적용하기 위해 RequestBodyAdvice 를 적용하였습니다.


## 테스트 방법 :hammer_and_wrench:
* 테스트에 사용된 입력은 다음과 같습니다.
<img width="748" alt="image" src="https://github.com/togather-2024/togather-backend/assets/37106166/ce04d5f0-beb9-4707-b355-7cc4c61ff455">

* 이전에는 이 값이 그대로 저장되었습니다 (9시에서 10시) 에 예약 진행
* 그러나 이제는 그 값이 그대로 적용되면 안됩니다. 위의 경우 UTC이기 때문에 한국 시간으로 18-19시 예약을 의미합니다. DB에도 그렇게 저장되어야 합니다.
* 27번 row는 변경 이전의 저장 DB, 28번 row는 변경 이후의 DB 입니다. 
<img width="943" alt="image" src="https://github.com/togather-2024/togather-backend/assets/37106166/f4b13767-6f2d-4c52-a249-b8b670708d2e">

