### PR TITLE
Feature: refactor bookmark related methods

### DIFF
--- a/togather-common/src/main/java/com/togather/member/service/MemberService.java
+++ b/togather-common/src/main/java/com/togather/member/service/MemberService.java
@@ -88,11 +88,25 @@ public class MemberService {
                 .orElseThrow(RuntimeException::new);
     }
 
+    /*
+    This method is used when login is required.
+     */
     public MemberDto findByAuthentication(Authentication authentication) {
         String userEmail = authentication.getName();
         return memberConverter.convertToDto(memberRepository.findByEmail(userEmail).orElseThrow(
                 () -> new UsernameNotFoundException("cannot find user by authentication")
         ));
+    }
+
+    /*
+    This method is used when login is optional - just to check
+     */
+    public MemberDto findNullableByAuthentication(Authentication authentication) {
+        try {
+            return findByAuthentication(authentication);
+        } catch (UsernameNotFoundException e) {
+            return null;
+        }
     }
 
     public void checkDuplicateMember(String email) {

--- a/togather-common/src/main/java/com/togather/partyroom/bookmark/service/PartyRoomBookmarkService.java
+++ b/togather-common/src/main/java/com/togather/partyroom/bookmark/service/PartyRoomBookmarkService.java
@@ -75,4 +75,11 @@ public class PartyRoomBookmarkService {
 
         return partyRoomBookmarkDtoList;
     }
+
+    public boolean hasBookmarked(MemberDto memberDto, long partyRoomId) {
+        Member member = memberConverter.convertToEntity(memberDto);
+        PartyRoom partyRoom = partyRoomService.findById(partyRoomId);
+
+        return partyRoomBookmarkRepository.findByMemberAndPartyRoom(member, partyRoom) != null;
+    }
 }

--- a/togather-common/src/main/java/com/togather/partyroom/reservation/service/PartyRoomReservationService.java
+++ b/togather-common/src/main/java/com/togather/partyroom/reservation/service/PartyRoomReservationService.java
@@ -136,7 +136,7 @@ public class PartyRoomReservationService {
         PartyRoomReservationDto partyRoomReservationDto = partyRoomReservationConverter.convertToDto(partyRoomReservationRepository.findById(reservationId)
                 .orElseThrow(RuntimeException::new));
 
-        PartyRoomDetailDto partyRoomDetailDto = partyRoomService.findDetailDtoById(partyRoomReservationDto.getPartyRoomDto().getPartyRoomId(), partyRoomReservationDto.getReservationGuestDto());
+        PartyRoomDetailDto partyRoomDetailDto = partyRoomService.findDetailDtoById(partyRoomReservationDto.getPartyRoomDto().getPartyRoomId());
 
         PartyRoomReservationResponseDto partyRoomReservationResponseDto = PartyRoomReservationResponseDto.builder()
                 .partyRoomReservationDto(partyRoomReservationDto)

--- a/togather-web/src/main/java/com/togather/partyroom/core/PartyRoomController.java
+++ b/togather-web/src/main/java/com/togather/partyroom/core/PartyRoomController.java
@@ -121,15 +121,7 @@ public class PartyRoomController {
     @ApiResponse(responseCode = "403", description = "has no role or is not owner of party room", content = @Content)
     @AddJsonFilters(filters = MEMBER_DTO_EXCLUDE_PII_WITH_NAME)
     public MappingJacksonValue getPartyRoomDetail(@PathVariable("id") long partyRoomId) {
-        MemberDto loginUser;
-
-        try {
-            loginUser = memberService.findByAuthentication(SecurityContextHolder.getContext().getAuthentication());
-        } catch (UsernameNotFoundException e){
-            loginUser = null;
-        }
-
-        return new MappingJacksonValue(partyRoomService.findDetailDtoById(partyRoomId, loginUser));
+        return new MappingJacksonValue(partyRoomService.findDetailDtoById(partyRoomId));
     }
 
     @GetMapping("/tags/getPopular")


### PR DESCRIPTION
## Refactor 할 수 있는 부분을 찾아봅시다 :memo:
1. 로그인 여부를 판단하는 메서드가 (로그인이 없을 시 )반드시 Exception을 뱉게 되어있습니다. 그래서 지금 파티룸 조회처럼 로그인이 필수적이지 않은 곳에서는 컨트롤러 내에서 try/catch 를 써야 합니다.
<img width="796" alt="image" src="https://github.com/togather-2024/togather-backend/assets/37106166/7f293b36-192a-4652-bb26-3ece85cf5cc6">

2. PartyRoomService#findDetailDtoById 의 파라미터가 변경되었습니다. 기존에 partyRoomId만 받는 것에서 memberDto도 추가되었습니다. 그런데 사실 함수 이름도 그렇긴하지만 memberDto 파라미터가 좀 어색하긴 합니다. 지금은 컨트롤러 뿐 아니라 ReservationService 에서도 이 메서드를 쓰고 있어서 이 메서드의 변경도 불가피합니다. 1. 즐겨찾기 기능 때문에 2. 파티룸조회 메서드를 수정했는데 3. 예약 메서드가 영향을 받는다면 예상치 못한 side effect가 생길 수 있습니다.

3. findDetailDto 내부에서 특정 회원이 특정 파티룸에 좋아요를 했는지 안했는지를 반환하는 과정이 조금 복잡해 보입니다. 
  3.1. 회원의 모든 즐겨찾기 내역 가져오고
  3.2. 그 내역 안에 원하는 파티룸이 있는지 조회
  그런데 이 과정은 즐겨찾기 서비스에서 진행되는게 더 적합해 보입니다. 뿐만 아니라 3.1, 3.2 과정 자체도 축약할 수 있을 것 같아요


## Refactoring
1. 지금까지는 로그인이 강제되는 API 에 대해서 반드시 exception 을 발생하는 메서드를 사용했습니다. 이번 경우처럼 로그인이 optional 이고, 여부만 확인하기 위한 메서드를 생성하면 될 것 같습니다. 다만 컨트롤러가 아니라 MemberService 에서 새로운 메서드를 만들어서 사용하면 될 것 같아요.
<img width="671" alt="image" src="https://github.com/togather-2024/togather-backend/assets/37106166/121d69fd-8eaf-4c68-8841-912e2c905743">

2. 위에서 만든 메서드를 반드시 컨트롤러에서 사용할 필요가 없습니다. 왜냐면 Authentication 정보는 ThreadLocal 변수인 SecurityContext에 저장되어 있기 때문입니다. (제가 로그인 관련해서 공유드렸다시피 SecurityContext 는 전역변수처럼 사용할 수 있습니다). SecurityContext 를 전역변수처럼 사용할 수 있는 강점이 이런 데서 나옵니다. MemberDto 타입의 파라미터를 받을 필요 없이 (별도의 수정 없이) 기존의 partyRoomId 만 파라미터로 받고도 로그인한 유저의 정보를 파악할 수 있습니다. 그래서 컨트롤러가 아닌 Service 메서드에서 유저의 로그인 여부를 판단할 수 있습니다. 
<img width="1028" alt="image" src="https://github.com/togather-2024/togather-backend/assets/37106166/9e75e66a-8e83-45f6-8e54-6cf898cfd9ac">

3. 특정 회원이 특정 파티룸을 즐겨찾기 했는지 여부를 반환하는 로직을 partyRoomService가 아닌 BookmarkService로 이관시킵니다. 또한 토글 형식이 아니고 데이터가 있으면 즐겨찾기를 누름 / 데이터가 없으면 즐겨찾기를 누르지않음 이므로, 이미 존재하는 repository 메서드를 재활용 할 수 있습니다.
<img width="826" alt="image" src="https://github.com/togather-2024/togather-backend/assets/37106166/7bbe41e2-3c83-4556-894b-fa0b39ee550b">



