### PR TITLE
[TEST REQUIRED] Feature: party room search feature

### DIFF
--- a/togather-common/build.gradle
+++ b/togather-common/build.gradle
@@ -3,6 +3,12 @@ dependencies {
     implementation "com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4"
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    //QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 bootJar { enabled = false }

--- a/togather-common/src/main/java/com/togather/partyroom/core/model/PartyRoomSearchQueryDto.java
+++ b/togather-common/src/main/java/com/togather/partyroom/core/model/PartyRoomSearchQueryDto.java
@@ -1,0 +1,17 @@
+package com.togather.partyroom.core.model;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+public class PartyRoomSearchQueryDto {
+    private String sido;
+    private String sigungu;
+    private LocalDate date;
+    private Integer guestCount;
+    private List<String> keywords;
+    private int pageNum = 1;
+    private int pageSize = 10;
+}

--- a/togather-common/src/main/java/com/togather/partyroom/core/repository/PartyRoomCustomRepository.java
+++ b/togather-common/src/main/java/com/togather/partyroom/core/repository/PartyRoomCustomRepository.java
@@ -1,0 +1,10 @@
+package com.togather.partyroom.core.repository;
+
+import com.togather.partyroom.core.model.PartyRoom;
+import com.togather.partyroom.core.model.PartyRoomSearchQueryDto;
+
+import java.util.List;
+
+public interface PartyRoomCustomRepository {
+    List<PartyRoom> search(PartyRoomSearchQueryDto partyRoomSearchQueryDto);
+}

--- a/togather-common/src/main/java/com/togather/partyroom/core/repository/PartyRoomRepository.java
+++ b/togather-common/src/main/java/com/togather/partyroom/core/repository/PartyRoomRepository.java
@@ -3,5 +3,6 @@ package com.togather.partyroom.core.repository;
 import com.togather.partyroom.core.model.PartyRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PartyRoomRepository extends JpaRepository<PartyRoom, Long> {
+
+public interface PartyRoomRepository extends JpaRepository<PartyRoom, Long>, PartyRoomCustomRepository {
 }

--- a/togather-common/src/main/java/com/togather/partyroom/core/repository/PartyRoomRepositoryImpl.java
+++ b/togather-common/src/main/java/com/togather/partyroom/core/repository/PartyRoomRepositoryImpl.java
@@ -1,0 +1,89 @@
+package com.togather.partyroom.core.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.togather.partyroom.core.model.PartyRoom;
+import com.togather.partyroom.core.model.PartyRoomSearchQueryDto;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.togather.partyroom.core.model.QPartyRoom.partyRoom;
+import static com.togather.partyroom.location.model.QPartyRoomLocation.partyRoomLocation;
+import static com.togather.partyroom.core.model.QPartyRoomOperationDay.partyRoomOperationDay;
+import static com.togather.partyroom.tags.model.QPartyRoomCustomTag.partyRoomCustomTag;
+import static com.togather.partyroom.tags.model.QPartyRoomCustomTagRel.partyRoomCustomTagRel;
+
+public class PartyRoomRepositoryImpl implements PartyRoomCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public PartyRoomRepositoryImpl(EntityManager entityManager) {
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public List<PartyRoom> search(PartyRoomSearchQueryDto partyRoomSearchQueryDto) {
+        Pageable page = PageRequest.of(partyRoomSearchQueryDto.getPageNum() - 1, partyRoomSearchQueryDto.getPageSize());
+
+        List<PartyRoom> result = jpaQueryFactory
+                .select(partyRoom)
+                .from(partyRoom)
+                .leftJoin(partyRoomLocation).on(partyRoom.eq(partyRoomLocation.partyRoom))
+                .leftJoin(partyRoomOperationDay).on(partyRoom.eq(partyRoomOperationDay.partyRoom))
+                .leftJoin(partyRoomCustomTagRel).on(partyRoom.eq(partyRoomCustomTagRel.partyRoom))
+                .leftJoin(partyRoomCustomTag).on(partyRoomCustomTag.eq(partyRoomCustomTagRel.partyRoomCustomTag))
+
+                .where(sidoEquals(partyRoomSearchQueryDto.getSido()),
+                        sigunguEquals(partyRoomSearchQueryDto.getSigungu()),
+                        opensAt(partyRoomSearchQueryDto.getDate()),
+                        guestCapacityGoe(partyRoomSearchQueryDto.getGuestCount()),
+                        containsKeyword(partyRoomSearchQueryDto.getKeywords()))
+                .distinct()
+                .offset(page.getOffset())
+                .limit(page.getPageSize())
+                .fetch();
+
+        return result;
+    }
+
+    private BooleanExpression sidoEquals(String sido) {
+        if (StringUtils.hasText(sido)) {
+            return partyRoomLocation.sido.eq(sido);
+        }
+        return null;
+    }
+
+    private BooleanExpression sigunguEquals(String sigungu) {
+        if (StringUtils.hasText(sigungu)) {
+            return partyRoomLocation.sigungu.eq(sigungu);
+        }
+        return null;
+    }
+
+    private BooleanExpression opensAt(LocalDate date) {
+        if (date != null) {
+            return partyRoomOperationDay.operationDay.eq(date.getDayOfWeek());
+        }
+        return null;
+    }
+
+    private BooleanExpression guestCapacityGoe(Integer guestCount) {
+        if (guestCount != null) {
+            return partyRoom.guestCapacity.goe(guestCount);
+        }
+        return null;
+    }
+
+    private BooleanExpression containsKeyword(List<String> keywords) {
+        if (CollectionUtils.isEmpty(keywords)) {
+            return null;
+        }
+        return partyRoomCustomTag.tagContent.in(keywords);
+    }
+}

--- a/togather-common/src/main/java/com/togather/partyroom/core/repository/PartyRoomRepositoryImpl.java
+++ b/togather-common/src/main/java/com/togather/partyroom/core/repository/PartyRoomRepositoryImpl.java
@@ -52,6 +52,19 @@ public class PartyRoomRepositoryImpl implements PartyRoomCustomRepository {
         return result;
     }
 
+    /**
+     * Returns if sido of party room is equal to the "sido" field of user input
+     * If user input field of "sido" is empty(or null), then the user did not enter this field
+     * Therefore, if this field is null, we should serve all partyRooms REGARDLESS of sido
+     *
+     * 파티룸의 '시/도' 정보가 유저가 검색 필드로 입력한 '시/도' 정보와 일치하는지를 확인하는 메서드입니다.
+     * 만약 이 필드가 유효하다면(사용자가 값을 입력했다면), 파티룸의 위치와 사용자의 입력값이 일치하는 파티룸만 찾습니다.
+     * 만약 이 필드가 비어있다면, 사용자가 값을 입력하지 않았다는 의미입니다. 그렇다면 '시/도' 조건은 확인하지 않고 다른 모든
+     * 조건을 만족하는 파티룸을 반환해야 합니다. ('시/도' 는 판별하지 않습니다)
+     *
+     * 실제로 사용자가 '시/도' 필드를 입력하지 않아서 반환값(BooleanExpression)이 null 이면 위 쿼리에서 where(null, ...) 이 실행되게 되고,
+     * 시/도 조건은 검색하지 않습니다.
+     */
     private BooleanExpression sidoEquals(String sido) {
         if (StringUtils.hasText(sido)) {
             return partyRoomLocation.sido.eq(sido);
@@ -66,12 +79,28 @@ public class PartyRoomRepositoryImpl implements PartyRoomCustomRepository {
         return null;
     }
 
+    /**
+     * Returns if the partyRoom is opened at the date.
+     * if 'date' field has a valid value, we compare the 'operationDays' of the party room and return only valid party rooms.
+     * if 'date' field has an invalid value, we skip the "check if the party room opens at a specific date" logic.
+     *
+     * 파티룸이 해당 날짜에 여는지 확인합니다.
+     * (위의 시/도 필드와 동일하게) 사용자가 유효한 값을 입력했다면, operationDays를 찾아서 해당 날짜에 영업하는 파티룸만 반환합니다.
+     * 사용자가 값을 입력하지 않았다면, 날짜는 검색하지 않겠다는 의미이므로 날짜와 관계없이 모든 파티룸을 반환합니다.
+     */
+
     private BooleanExpression opensAt(LocalDate date) {
         if (date != null) {
             return partyRoomOperationDay.operationDay.eq(date.getDayOfWeek());
         }
         return null;
     }
+
+    /**
+     * 사용자가 입력한 사용 인원과 파티룸이 최대로 수용할 수 있는 인원을 비교합니다.
+     * 사용자가 이용 인원을 입력했다면 파티룸의 최대 수용 인원(guestCapacity) 를 비교해서 capacity >= guestCount (GOE: Greater or equal) 한 파티룸만 반환합니다.
+     * 마찬가지로 이용인원을 입력하지 않았다면 파티룸의 최대 수용 인원 조건을 확인하지 않습니다.
+     */
 
     private BooleanExpression guestCapacityGoe(Integer guestCount) {
         if (guestCount != null) {
@@ -80,6 +109,10 @@ public class PartyRoomRepositoryImpl implements PartyRoomCustomRepository {
         return null;
     }
 
+    /**
+     * 키워드 판별 로직입니다. 사용자가 아무 키워드도 입력하지 않았다면, 파티룸의 키워드를 판별하지 않습니다.
+     * 1개 이상의 키워드를 입력했다면, 그 중 하나라도 태그로 등록한 파티룸은 검색의 대상이 됩니다.
+     */
     private BooleanExpression containsKeyword(List<String> keywords) {
         if (CollectionUtils.isEmpty(keywords)) {
             return null;

--- a/togather-common/src/main/java/com/togather/partyroom/core/service/PartyRoomService.java
+++ b/togather-common/src/main/java/com/togather/partyroom/core/service/PartyRoomService.java
@@ -5,10 +5,7 @@ import com.togather.member.service.MemberService;
 import com.togather.partyroom.bookmark.model.PartyRoomBookmarkDto;
 import com.togather.partyroom.bookmark.service.PartyRoomBookmarkService;
 import com.togather.partyroom.core.converter.PartyRoomConverter;
-import com.togather.partyroom.core.model.PartyRoom;
-import com.togather.partyroom.core.model.PartyRoomDetailDto;
-import com.togather.partyroom.core.model.PartyRoomDto;
-import com.togather.partyroom.core.model.PartyRoomOperationDayDto;
+import com.togather.partyroom.core.model.*;
 import com.togather.partyroom.core.repository.PartyRoomRepository;
 import com.togather.partyroom.image.model.PartyRoomImageDto;
 import com.togather.partyroom.image.model.PartyRoomImageType;
@@ -166,4 +163,11 @@ public class PartyRoomService {
                 .orElseThrow(RuntimeException::new);
     }
 
+    public List<PartyRoomDetailDto> searchPartyRoom(PartyRoomSearchQueryDto partyRoomSearchQueryDto) {
+        List<PartyRoom> partyRooms = partyRoomRepository.search(partyRoomSearchQueryDto);
+        return partyRooms.stream()
+                .map(PartyRoom::getPartyRoomId)
+                .map(this::findDetailDtoById)
+                .toList();
+    }
 }

--- a/togather-web/src/main/java/com/togather/partyroom/core/PartyRoomController.java
+++ b/togather-web/src/main/java/com/togather/partyroom/core/PartyRoomController.java
@@ -5,8 +5,10 @@ import com.togather.common.s3.S3ImageUploader;
 import com.togather.common.s3.S3ObjectDto;
 import com.togather.member.model.MemberDto;
 import com.togather.member.service.MemberService;
+import com.togather.partyroom.core.model.PartyRoomDetailDto;
 import com.togather.partyroom.core.model.PartyRoomDto;
 import com.togather.partyroom.core.model.PartyRoomOperationDayDto;
+import com.togather.partyroom.core.model.PartyRoomSearchQueryDto;
 import com.togather.partyroom.core.service.PartyRoomService;
 import com.togather.partyroom.location.model.PartyRoomLocationDto;
 import com.togather.partyroom.register.PartyRoomRequestDto;
@@ -116,9 +118,7 @@ public class PartyRoomController {
     @GetMapping("/detail/{id}")
     @ResponseBody
     @Operation(summary = "partyRoom detail info API", description = "파티룸 조회 API")
-    @ApiResponse(responseCode = "200", description = "returns response with string 'ok' when deleted successfully")
-    @ApiResponse(responseCode = "401", description = "user not logged in (No JWT token)", content = @Content)
-    @ApiResponse(responseCode = "403", description = "has no role or is not owner of party room", content = @Content)
+    @ApiResponse(responseCode = "200", description = "returns detail info of party room", content = @Content(schema = @Schema(implementation = PartyRoomDetailDto.class)))
     @AddJsonFilters(filters = MEMBER_DTO_EXCLUDE_PII_WITH_NAME)
     public MappingJacksonValue getPartyRoomDetail(@PathVariable("id") long partyRoomId) {
         return new MappingJacksonValue(partyRoomService.findDetailDtoById(partyRoomId));
@@ -131,6 +131,14 @@ public class PartyRoomController {
     public ResponseEntity<List<String>> getPopularTags(@RequestParam(required = false, defaultValue = "10") int limit) {
         List<String> tagContents = partyRoomCustomTagService.getPopularTags(limit);
         return ResponseEntity.ok(tagContents);
+    }
+
+    @GetMapping("/search")
+    @ResponseBody
+    @Operation(summary = "search party rooms based on pagination - returns all if no condition is applied")
+    @ApiResponse(responseCode = "200", description = "returns detail info of party room", content = @Content(schema = @Schema(implementation = PartyRoomDetailDto.class)))
+    public MappingJacksonValue searchPartyRoom(PartyRoomSearchQueryDto partyRoomSearchQueryDto) {
+        return new MappingJacksonValue(partyRoomService.searchPartyRoom(partyRoomSearchQueryDto));
     }
 
 }


### PR DESCRIPTION
## 개요 :mag:
* Add party room search feature(API)


## 작업사항 :memo:
* use queryDsl for search query and joining tables
* QFiles used in queryDsl are generated on build time - QueryDsl library detects files with @Entity annotation and generates a Qfile of entities.

* 사용자는 여러 조건으로 검색할 수 있습니다. 그리고 이 중 일부는 비어있을 수도 있습니다 ( 예 - 날짜는 2024-04-11 을 입력했지만 장소 조건은 입력하지 않을 수 있습니다)
* 이때 장소 조건을 입력하지 않았다는 뜻은 장소가 등록되지 않은 파티룸을 반환해달라는게 아니라 (실제로 장소가 등록되자 않은 파티룸은 없겠지요 ㅎㅎ) _**"장소와 관계없이 날짜 조건만 만족하면 다 내려주세요"**_ 의 의미입니다.
* 따라서 빈 조건(사용자가 입력하지 않은 조건)이 검색 쿼리의 핵심이 되며, 검색 쿼리가 어려운 이유입니다. 정리하자면
    *  사용자가 특정 조건(e.g. 날짜)의 값을 입력했다면 -> 해당 조건을 만족하는 파티룸들을 반환(해당 날짜에 영업중인 파티룸만 반환)
    *  사용자가 특정 조건(e.g. 날짜)의 값을 입력하지 않았다면 -> 해당 조건을 건너뛰고! (모든 파티룸들이 날짜 조건을 만족한다고 가정하고 다른 검색 조건만 확인해서 ) 파티룸을 반환해야 합니다

* 이처럼 DB에 쿼리를 할 때 쿼리의 형식은 유지되면서 파라미터만 변경되는게 아니라, 특정 조건에 따라 query의 형식 자체가 바뀌는 쿼리를 '동적 쿼리' 라고 하고, 이를 유연하게 해결할 수 있는 메서드 중 하나가 queryDsl 입니다.

* PartyRoomRepositoryImpl 이 queryDsl 을 사용한 Repository 클래스입니다. 그리고 queryDsl 에 사용되는 Q클래스들은 개발자가 직접 만드는 것이 아니라, @Entity 태그가 붙은 파일을 queryDsl 라이브러리가 인식해서 빌드시에 자동으로 generate 됩니다. (이 클래스들은 build 의 하위 항목에 생성되기 때문에 git의 대상이 되지 않습니다. 이 또한 아주 간편합니다.)
* PartyRoomRepositoryImpl 의 private method들이 구체적인 검색 로직입니다. 주석으로 달아놓았지만 입력으로 주어지는 파라미터가 null인 경우는 사용자가 입력하지 않은 경우이며, private method들도 null을 반환합니다. 이 private method들은 메인 쿼리의 where 절에서 활용되는데 null인 경우, 아무 동작도 하지 않기 때문에 사용자가 특정 조건에 빈 값을 입력했을 경우, 해당 조건은 건너뛰고 검색 결과를 가져옵니다.

<img width="775" alt="image" src="https://github.com/togather-2024/togather-backend/assets/37106166/091f59d1-b0fd-4129-a04d-f6f2a941a5c0">
<img width="602" alt="image" src="https://github.com/togather-2024/togather-backend/assets/37106166/a3f64295-aa4c-422b-a37f-7083a0a49031">






## 테스트 방법 :hammer_and_wrench:
* Needs testing with mock data
