### PR TITLE
fix: several modifications

### DIFF
--- a/togather-common/src/main/java/com/togather/member/converter/MemberConverter.java
+++ b/togather-common/src/main/java/com/togather/member/converter/MemberConverter.java
@@ -16,13 +16,17 @@ public class MemberConverter {
         if (member == null)
             return null;
 
+        String resourceUrl = null;
+        if (member.getProfilePicFile() != null)
+            resourceUrl = s3ImageUploader.getResourceUrl(member.getProfilePicFile());
+
         return MemberDto.builder()
                 .memberSrl(member.getMemberSrl())
                 .memberName(member.getMemberName())
                 .password(member.getPassword())
                 .role(member.getRole())
                 .email(member.getEmail())
-                .profilePicFile(s3ImageUploader.getResourceUrl(member.getProfilePicFile()))
+                .profilePicFile(resourceUrl)
                 .build();
     }
 

--- a/togather-web/src/main/java/com/togather/common/response/ResponseFilter.java
+++ b/togather-web/src/main/java/com/togather/common/response/ResponseFilter.java
@@ -23,8 +23,6 @@ public enum ResponseFilter {
 
     MEMBER_DTO_EXCLUDE_ALL(MemberDto.class, new String[]{"memberSrl", "memberName", "password", "role", "email", "profilePicFile"}),
 
-    MEMBER_DTO_EXCLUDE_PW(MemberDto.class, new String[]{"memberSrl", "password"}),
-
 
     PARTY_ROOM_DTO_SIMPLE(PartyRoomDto.class, new String[] {"partyRoomDesc"}),
 

--- a/togather-web/src/main/java/com/togather/member/MemberController.java
+++ b/togather-web/src/main/java/com/togather/member/MemberController.java
@@ -69,7 +69,7 @@ public class MemberController {
     @ApiResponse(responseCode = "200", description = "success", content = @Content(schema = @Schema(implementation = MemberDto.class)))
     @PreAuthorize("isAuthenticated()")
     @ApiResponse(responseCode = "401", description = "user not logged in (No JWT token)", content = @Content)
-    @AddJsonFilters(filters = ResponseFilter.MEMBER_DTO_EXCLUDE_PW)
+    @AddJsonFilters(filters = ResponseFilter.MEMBER_DTO_EXCLUDE_PASSWORD)
     public MappingJacksonValue getUserInfo() {
         MemberDto loginUser = memberService.findByAuthentication(SecurityContextHolder.getContext().getAuthentication());
         return new MappingJacksonValue(loginUser);


### PR DESCRIPTION
## 개요 :mag:
<!-- 어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 남겨주세요. -->
- 회원의 프로필 사진이 없을 시 s3 버킷 패스만 전달되어 사진이 없다는 걸 캐치하지 못하는 이슈 발생

## 작업사항 :memo:
<!-- 해당 이슈사항을 해결하기 위해 어떤 작업을 했는지 남겨주세요. -->
- 회원 정보 조회 api의 memberSrl 필드 필터링에서 제외
- 회원의 프로필 사진이 없을 시 null로 반환되게 핸들링

## 테스트 방법 :hammer_and_wrench:
<!-- 리뷰하는 사람이 어떻게 테스트할 수 있을지 간략히 써주세요. -->
- 스웨거를 활용한 테스트 완료